### PR TITLE
Gracefully handle errors when the type stored in the sync method attribute is wrong

### DIFF
--- a/ShowDelegates/ShowDelegates.cs
+++ b/ShowDelegates/ShowDelegates.cs
@@ -239,9 +239,9 @@ namespace ShowDelegates
                         {
                             method = info.method.IsStatic ? info.method.CreateDelegate(delegateType) : info.method.CreateDelegate(delegateType, worker);
                         }
-                        catch
+                        catch (Exception e)
                         {
-                            Error($"Error when trying to create a delegate for {info.method.DeclaringType.Name}.{info.method.Name} with sync method type {delegateType.GetNiceName()}");
+                            Error($"Error when trying to create a delegate for {info.method.DeclaringType.Name}.{info.method.Name} with sync method type {delegateType.GetNiceName()}\n{e}");
                             ui.Text("<color=red>" + funName(delegateType.ToString(), info.method), true, new Alignment?(Alignment.MiddleLeft));
                             continue;
                         }

--- a/ShowDelegates/ShowDelegates.cs
+++ b/ShowDelegates/ShowDelegates.cs
@@ -1,13 +1,13 @@
-﻿using HarmonyLib;
+﻿using Elements.Core;
+using FrooxEngine;
+using FrooxEngine.ProtoFlux;
+using FrooxEngine.UIX;
+using HarmonyLib;
 using ResoniteModLoader;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Collections.Generic;
-using FrooxEngine;
-using FrooxEngine.UIX;
-using Elements.Core;
-using FrooxEngine.ProtoFlux;
 using System.Reflection.Emit;
 
 namespace ShowDelegates
@@ -234,7 +234,17 @@ namespace ShowDelegates
                             }
                         }
 
-                        var method = info.method.IsStatic ? info.method.CreateDelegate(delegateType) : info.method.CreateDelegate(delegateType, worker);
+                        Delegate method = null;
+                        try
+                        {
+                            method = info.method.IsStatic ? info.method.CreateDelegate(delegateType) : info.method.CreateDelegate(delegateType, worker);
+                        }
+                        catch
+                        {
+                            Error($"Error when trying to create a delegate for {info.method.DeclaringType.Name}.{info.method.Name} with sync method type {delegateType.GetNiceName()}");
+                            ui.Text("<color=red>" + funName(delegateType.ToString(), info.method), true, new Alignment?(Alignment.MiddleLeft));
+                            continue;
+                        }
 
                         delegateFunc.MakeGenericMethod(delegateType).Invoke(null, new object[]
                         {


### PR DESCRIPTION
Also I accidentally sorted the usings or something

Fixes #12 